### PR TITLE
Enable turbo boost

### DIFF
--- a/src/polyfills.ts
+++ b/src/polyfills.ts
@@ -43,7 +43,7 @@ import 'core-js/es6/set';
 
 /** Evergreen browsers require these. **/
 // Used for reflect-metadata in JIT. If you use AOT (and only Angular decorators), you can remove.
-import 'core-js/es7/reflect';
+// import 'core-js/es7/reflect';
 
 
 /**


### PR DESCRIPTION
We don't need this polyfill because we use AOT (Angular v7 out of the box now removes this polyfill for performance gains). 