### PR TITLE
add height to eventbright form

### DIFF
--- a/src/app/home/signup/signup.component.html
+++ b/src/app/home/signup/signup.component.html
@@ -21,7 +21,7 @@
         <h5>Upcoming Session: <br>{{upcomingSession.date | date:'fullDate'}}, {{upcomingSession.time}}
           <br />{{upcomingSession.name}}</h5>
 <!--        <p>Note: wifi-enabled laptops are required to attend!</p>-->
-        <div style="width:100%; text-align:left;"><iframe [attr.src]="upcomingSessionTicketLink" frameborder="0" height="325" width="100%" vspace="0" hspace="0" marginheight="5" marginwidth="5" scrolling="auto" allowtransparency="true" title="Sign Up Form"></iframe></div>
+        <div style="width:100%; text-align:left;"><iframe [attr.src]="upcomingSessionTicketLink" frameborder="0" height="700" width="100%" vspace="0" hspace="0" marginheight="5" marginwidth="5" scrolling="auto" allowtransparency="true" title="Sign Up Form"></iframe></div>
       </div>
     </div>
     <div class="row">


### PR DESCRIPTION
added height to evenbright form to make it more useable

Before:
<img width="1247" alt="Screen Shot 2022-10-08 at 7 11 21 PM" src="https://user-images.githubusercontent.com/6856001/194731838-6b9eb695-5249-4e0a-8154-9b9a6422868d.png">


After:
<img width="1228" alt="Screen Shot 2022-10-08 at 7 11 29 PM" src="https://user-images.githubusercontent.com/6856001/194731843-ebcfb2e8-31fd-4c1f-9b81-ca2d0339429d.png">
