### PR TITLE
menu on mobile loads in a collapsed state

### DIFF
--- a/src/app/nav/nav.component.ts
+++ b/src/app/nav/nav.component.ts
@@ -6,8 +6,8 @@ import { Component, OnInit } from '@angular/core';
   styleUrls: ['./nav.component.scss']
 })
 export class NavComponent implements OnInit {
-  public isCollapsed = false;
-
+ public isCollapsed = true;
+ 
   constructor() { }
 
   ngOnInit(): void {

--- a/src/app/nav/nav.component.ts
+++ b/src/app/nav/nav.component.ts
@@ -6,8 +6,8 @@ import { Component, OnInit } from '@angular/core';
   styleUrls: ['./nav.component.scss']
 })
 export class NavComponent implements OnInit {
- public isCollapsed = true;
- 
+  public isCollapsed = true;
+
   constructor() { }
 
   ngOnInit(): void {


### PR DESCRIPTION
hamburger menu would load in an open state on mobile

Before, can see menu expanded on page load (refresh):
![before-menu-mobile](https://user-images.githubusercontent.com/6856001/194734625-02d67dc6-e7f5-438b-888c-d3f899e3b5b5.gif)

After, default state of menu is collapsed:
![after-menu-mobile](https://user-images.githubusercontent.com/6856001/194734643-259e0d1c-e049-421b-b7bb-ed89c2e017b2.gif)

